### PR TITLE
Remove udev

### DIFF
--- a/net.mancubus.SLADE.yaml
+++ b/net.mancubus.SLADE.yaml
@@ -99,8 +99,6 @@ modules:
     - sed -i 's|-o root -g root ||' ./Makefile.gnu
     - sed -i 's|/usr|/app|' ./Makefile.gnu
 
-- shared-modules/udev/udev-175.json
-
 - name: SFML
   buildsystem: cmake-ninja
   config-opts:


### PR DESCRIPTION
Since gnome 3.34 udev is provided in runtime.