### PR TITLE
Remove unneeded workarounds

### DIFF
--- a/net.mancubus.SLADE.yaml
+++ b/net.mancubus.SLADE.yaml
@@ -212,8 +212,3 @@ modules:
           tag-pattern: ^([\d.]+)$
       - type: patch
         path: soundfont.patch
-      - type: shell
-        commands:
-          - sed -i 's|target_link_libraries(slade -lstdc++fs)||g' cmake/unix.cmake
-          - sed -i 's|PK3_OUTPUT|PK3_DESTINATION|g' dist/CMakeLists.txt
-


### PR DESCRIPTION
The line: https://github.com/flathub/net.mancubus.SLADE/blob/438ca9ad89489b6537d52d9561822555aad57518/net.mancubus.SLADE.yaml#L217 was fixed in https://github.com/sirjuddington/SLADE/commit/29f8e23aa5e81d7fd1f5d74406f9e7a39dd7f072

---
and the line: https://github.com/flathub/net.mancubus.SLADE/blob/438ca9ad89489b6537d52d9561822555aad57518/net.mancubus.SLADE.yaml#L218 was fixed in https://github.com/sirjuddington/SLADE/commit/6abd8c369bb5d7b84c0d2a063fdcfea481a08689