### PR TITLE
Drop fmtlib module

### DIFF
--- a/net.mancubus.SLADE.yaml
+++ b/net.mancubus.SLADE.yaml
@@ -137,19 +137,6 @@ modules:
           - acc "$@"
         dest-filename: acc.sh
 
-  - name: fmt
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
-    sources:
-      - type: archive
-        url: https://github.com/fmtlib/fmt/archive/refs/tags/12.1.0.tar.gz
-        sha256: ea7de4299689e12b6dddd392f9896f08fb0777ac7168897a244a6d6085043fea
-        x-checker-data:
-          type: anitya
-          project-id: 11526
-          url-template: https://github.com/fmtlib/fmt/archive/refs/tags/$version.tar.gz
-
   - name: glad
     buildsystem: cmake-ninja
     config-opts:


### PR DESCRIPTION
GNOME runtime 49 already provides this module.

Fixes: https://github.com/flathub/net.mancubus.SLADE/issues/132